### PR TITLE
Remove vestigial keys from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
   },
   "license": "Apache-2.0",
   "private": true,
-  "main": "src/lib/eth.js",
-  "files": [
-    "src",
-    "truffle"
-  ],
   "scripts": {
     "postinstall": "echo \"\n\n\n\ncontracts included in this project require compilation on a fresh checkout: npm run truffle:compile\n\n\n\n\"",
     "pretest": "./ensure-ganache-running.sh || (npm run start:testrpc &)",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "git+https://github.com/Finhaven/DealToken.git"
   },
   "license": "Apache-2.0",
-  "private": true,
   "scripts": {
     "postinstall": "echo \"\n\n\n\ncontracts included in this project require compilation on a fresh checkout: npm run truffle:compile\n\n\n\n\"",
     "pretest": "./ensure-ganache-running.sh || (npm run start:testrpc &)",


### PR DESCRIPTION
**Summary**
Closes #3 — Remove `files`, `main`, and `private` from `package.json`

This PR fixes/implements the following **bugs/features**

* [x] Bug #3